### PR TITLE
Time to live

### DIFF
--- a/dcache.py
+++ b/dcache.py
@@ -8,7 +8,6 @@ from lzstring import LZString
 
 class Dinky:
     def __init__(self, dbfile: str = "dinkycache.db"):
-        self.days = 90 * (60 * 60 * 24)
         self.lz = LZString()
         self.db = dbfile
 
@@ -25,50 +24,74 @@ class Dinky:
                     f"('id' text, 'data' text, 'timestamp' int, "
                     f"PRIMARY KEY('id'))"
                 )
+        expired = []
+        with self._SQLite(self.db) as cur:
+            rows = cur.execute(
+                f"SELECT id, timestamp FROM 'dinkycache'"
+                f"WHERE timestamp > 0 ORDER BY timestamp ASC LIMIT 3"
+            )
+            for row in rows:
+                now = int(time())
+                print(
+                    f"init: timestamp {row['timestamp']} expires in {row['timestamp'] - now}"
+                )
+                if now > row["timestamp"]:
+                    expired.append(row["id"])
+        for item in expired:
+            self.delete(hash=item)
 
-    def read(self, id: str = False):
+    def read(self, id: str):
         result = False
-        if not id:
-            print("Dinkyread: id must be supplied")
+        hashed = sha256(id.encode("utf-8")).hexdigest()
+        with self._SQLite(self.db) as cur:
+            dbdata = cur.execute(
+                f"SELECT id, data, timestamp FROM dinkycache WHERE id = '{hashed}'"
+            ).fetchone()
+        if dbdata is not None:
+            now = int(time())
+            timestamp = int(dbdata["timestamp"])
+            if now < timestamp:
+                result_str = self.lz.decompressFromBase64(dbdata["data"])
+                result = json.loads(result_str)
+            else:
+                self.delete(id)
+        return result
+
+    def write(self, id: str, data: str, ttl: int = 172800):  # 48hours ttl
+        result = hashed = sha256(id.encode("utf-8")).hexdigest()
+        if ttl:
+            timestamp = int(time()) + int(ttl)
         else:
+            timestamp = 0
+        str_data = json.dumps(data)
+        compressed = self.lz.compressToBase64(str_data)
+        with self._SQLite(self.db) as cur:
+            cached = cur.execute(
+                f"SELECT COUNT() FROM dinkycache WHERE id = '{hashed}'"
+            ).fetchone()[0]
+            if cached > 0:
+                cur.execute(
+                    f"UPDATE dinkycache "
+                    f"SET data = '{compressed}', timestamp = '{timestamp}' "
+                    f"WHERE id = '{hashed}'"
+                )
+            else:
+                cur.execute(
+                    f"INSERT INTO dinkycache VALUES "
+                    f"('{hashed}', '{compressed}', '{timestamp}')"
+                )
+        return result
+
+    def delete(self, id: str = False, hash: str = False):
+        if id:
             hashed = sha256(id.encode("utf-8")).hexdigest()
-            now = int(time())
-            with self._SQLite(self.db) as cur:
-                dbdata = cur.execute(
-                    f"SELECT id, data, timestamp FROM dinkycache WHERE id = '{hashed}'"
-                ).fetchone()
-            if dbdata is not None:
-                ttl = dbdata["timestamp"]
-                if (now - ttl) < self.days:
-                    result_str = self.lz.decompressFromBase64(dbdata["data"])
-                    result = json.loads(result_str)
-        return result
-
-    def write(self, id: str = False, data: str = False):
-        result = False
-        if not id or not data:
-            print("Dinkywrite: id and data must be supplied")
+        elif hash:
+            hashed = hash
         else:
-            result = hashed = sha256(id.encode("utf-8")).hexdigest()
-            now = int(time())
-            str_data = json.dumps(data)
-            compressed = self.lz.compressToBase64(str_data)
-            with self._SQLite(self.db) as cur:
-                cached = cur.execute(
-                    f"SELECT COUNT() FROM dinkycache WHERE id = '{hashed}'"
-                ).fetchone()[0]
-                if cached > 0:
-                    cur.execute(
-                        f"UPDATE dinkycache "
-                        f"SET data = '{compressed}', timestamp = '{now}' "
-                        f"WHERE id = '{hashed}'"
-                    )
-                else:
-                    cur.execute(
-                        f"INSERT INTO dinkycache VALUES "
-                        f"('{hashed}', '{compressed}', '{now}')"
-                    )
-        return result
+            raise TypeError("delete() missing 1 required argument: 'id' or 'hash'")
+        with self._SQLite(self.db) as cur:
+            cur.execute(f"DELETE FROM dinkycache WHERE id = '{hashed}'")
+        return True
 
     class _SQLite:
         def __init__(self, file):


### PR DESCRIPTION
added .delete
changed ttl in to a timestamp for when the data should expire, with the option to set it to never expire
 - default value? never expire? it's set to 48 hours for now.

added check for expired data in init
 - slows the whole thing down by ~75%, from avg 1.5ms to 3.5ms per read operation

added some docstring
 - we need more

the [readme.mb](https://github.com/expergefacio/dinkycache/blob/master/README.md) should be updated at some point as well.